### PR TITLE
Simplify to use Number.isSafeInteger()

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 /**
- * Is allegenNum a number in the contiguous range of exactly and
+ * Is allegedNum a number in the contiguous range of exactly and
  * unambiguously representable natural numbers (non-negative integers)?
  *
  * <p>See <a href=
@@ -24,24 +24,16 @@
  * "https://mail.mozilla.org/pipermail/es-discuss/2013-July/031716.html"
  * >Allen Wirfs-Brock's suggested phrasing</a> on es-discuss.
  */
+
 function Nat(allegedNum) {
-  // TODO simplify by using Number.isSafeInteger
-  if (typeof allegedNum !== 'number') {
-    throw new RangeError('not a number');
+  if (!Number.isSafeInteger(allegedNum)) {
+    throw new RangeError('not a safe integer');
   }
-  // eslint-disable-next-line no-self-compare
-  if (allegedNum !== allegedNum) {
-    throw new RangeError('NaN not natural');
-  }
+
   if (allegedNum < 0) {
     throw new RangeError('negative');
   }
-  if (allegedNum % 1 !== 0) {
-    throw new RangeError('not integral');
-  }
-  if (allegedNum > Number.MAX_SAFE_INTEGER) {
-    throw new RangeError('too big');
-  }
+
   return allegedNum;
 }
 


### PR DESCRIPTION
## Description

This PR simplifies `Nat` to use `Number.isSafeInteger()`. In [the specification](https://www.ecma-international.org/ecma-262/6.0/#sec-number.issafeinteger), "when the Number.isSafeInteger is called with one argument number, the following steps are taken:

If Type(number) is not Number, return false.
If number is NaN, +∞, or −∞, return false.
Let integer be ToInteger(number).
If integer is not equal to number, return false.
If abs(integer) ≤ 2**53−1, return true.
Otherwise, return false."

Thus, we can remove:
1. The typeof check (line 23)
2. The NaN check (line 33)
3. The integer check (line 39)
4. The safe number check (line 42)

This leaves us with two checks. If `allegedNum` is not a safe integer or is negative, we throw a RangeError. Otherwise we return the number. 

## Considerations
By simplifying, we are removing the distinct RangeError messages. Do we want to do that?

## Test
`npm test`
