### PR TITLE
Support both ES6 Imports and CommonJS Imports

### DIFF
--- a/index-commonjs.js
+++ b/index-commonjs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Copyright (C) 2011 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -37,4 +39,4 @@ function Nat(allegedNum) {
   return allegedNum;
 }
 
-export default Nat;
+module.exports = Nat;

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,18 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "11.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.1.tgz",
+      "integrity": "sha512-XJHvu7fvycZ7ORTyThXiKCtld+R4Y1GGerYRrVSf/GhaNahRBIf/Nx+7Xh3AvI5nudOVt/L671CxHGkJt1/+hQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.7.tgz",
@@ -3003,6 +3015,17 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.1.2.tgz",
+      "integrity": "sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*",
+        "acorn": "^6.0.5"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run create-cjs && lint-staged"
+      "pre-commit": "npm run create-cjs && lint-staged && npm test"
     }
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "@agoric/nat",
   "version": "1.0.1",
   "description": "Ensures that a number is within the natural numbers (0, 1, 2...) or throws a RangeError",
-  "main": "index.js",
+  "main": "index-commonjs.js",
+  "module": "index.js",
   "scripts": {
     "test": "node test/test.js",
     "format": "prettier --write '**/*.{js,jsx}'",
-    "lint": "eslint '**/*.{js,jsx}'"
+    "lint": "eslint '**/*.{js,jsx}'",
+    "create-cjs": "rollup index.js --file index-commonjs.js --format cjs"
   },
   "repository": {
     "type": "git",
@@ -30,6 +32,7 @@
     "husky": "^1.3.1",
     "lint-staged": "^8.1.3",
     "prettier": "1.16.4",
+    "rollup": "^1.1.2",
     "tape": "^4.9.2"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "npm run create-cjs && lint-staged"
     }
   },
   "directories": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 /* eslint no-mixed-operators: "off" */
 
 const test = require('tape');
-const { Nat } = require('../index.js');
+const Nat = require('../index-commonjs.js');
 
 test('Nat() throws when not a natural number', t => {
   t.equal(Nat(0), 0);


### PR DESCRIPTION
## Description
This PR changes index.js to use ES6 Module syntax. It also autogenerates a CommonJS version index-commonjs.js. 

Package.json is changed to use index-commonjs.js as main, and index.js for modules.

Closes #5