### PR TITLE
add command for eslint-disable-stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "node -r esm test/test.js",
     "build": "rollup -c",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'"
+    "lint-check": "eslint '**/*.{js,jsx}'",
+    "eslint-disable-stats": "grep -R --exclude-dir=node_modules --include='*.js' 'eslint' . | wc -l | tr -d [:blank:]"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a simple script for getting the count of times that eslint rules are disabled. 