### PR TITLE
Add a CircleCI job that runs npm audit and files a PR if anything is fixable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
   nightly:
      triggers:
        - schedule:
-           cron: "0 0 * * *"
+           cron: "0 1 * * *"
            filters:
              branches:
                only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ workflows:
   nightly:
      triggers:
        - schedule:
-           cron: "0 1 * * *"
+           cron: "30 1 * * *"
            filters:
              branches:
                only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
               cd /go/src/github.com/github/hub
               go install github.com/github/hub
       - run:
-          name: Submit PR if npm audit --fix makes changes
+          name: Submit PR if npm audit fix makes changes
           command: ./scripts/npm-audit-fix.sh
      
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,25 @@ jobs:
             cd integration-test
             npm run test:post-release
 
+  npm_audit_node_11: &npm_audit
+    docker:
+      - image: circleci/golang:1.12.0-node
+    steps: 
+      - checkout
+      - run:
+          name: install hub
+          command: |
+              set -xe
+              go get -u -d github.com/github/hub
+              cd /go/src/github.com/github/hub
+              go install github.com/github/hub
+      - run:
+          name: Submit PR if npm audit --fix makes changes
+          command: ./scripts/npm-audit-fix.sh
+     
+
+
+
             
 workflows:
   version: 2
@@ -95,3 +114,4 @@ workflows:
                  - master
      jobs:
        - post_release_test_integration
+       - npm_audit_node_11

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ typings/
 
 # dist
 dist/
+
+# bundler integration tests
 integration-test/.cache
 integration-test/bundles
 integration-test/transform-tests/output
+
+# hub
+hub

--- a/scripts/npm-audit-fix.sh
+++ b/scripts/npm-audit-fix.sh
@@ -1,0 +1,32 @@
+git clone https://github.com/AgoricBot/nat.git
+cd nat
+
+if npm audit ; then
+    echo "Nothing to fix"
+else
+    git config user.email "kate+agoricbot@agoric.com"
+    git config user.name "AgoricBot"
+    git checkout -b npm-audit-fix
+    npm audit --fix
+    git add . 
+    git commit -m "results of running npm audit --fix"
+    git remote set-url origin https://AgoricBot:$GITHUB_TOKEN@github.com/AgoricBot/nat.git
+    git push origin npm-audit-fix
+    hub pull-request --no-edit --base Agoric/nat:master
+fi
+
+# Do the same thing with the package.json in the integration-test folder
+cd integration-test
+if npm audit ; then
+    echo "Nothing to fix"
+else
+    git config user.email "kate+agoricbot@agoric.com"
+    git config user.name "AgoricBot"
+    git checkout -b npm-audit-fix
+    npm audit --fix
+    git add . 
+    git commit -m "results of running npm audit --fix"
+    git remote set-url origin https://AgoricBot:$GITHUB_TOKEN@github.com/AgoricBot/nat.git
+    git push origin npm-audit-fix
+    hub pull-request --no-edit --base Agoric/nat:master
+fi

--- a/scripts/npm-audit-fix.sh
+++ b/scripts/npm-audit-fix.sh
@@ -7,9 +7,9 @@ else
     git config user.email "kate+agoricbot@agoric.com"
     git config user.name "AgoricBot"
     git checkout -b npm-audit-fix
-    npm audit --fix
+    npm audit fix
     git add . 
-    git commit -m "results of running npm audit --fix"
+    git commit -m "results of running npm audit fix"
     git remote set-url origin https://AgoricBot:$GITHUB_TOKEN@github.com/AgoricBot/nat.git
     git push origin npm-audit-fix
     hub pull-request --no-edit --base Agoric/nat:master
@@ -23,9 +23,9 @@ else
     git config user.email "kate+agoricbot@agoric.com"
     git config user.name "AgoricBot"
     git checkout -b npm-audit-fix
-    npm audit --fix
+    npm audit fix
     git add . 
-    git commit -m "results of running npm audit --fix"
+    git commit -m "results of running npm audit fix"
     git remote set-url origin https://AgoricBot:$GITHUB_TOKEN@github.com/AgoricBot/nat.git
     git push origin npm-audit-fix
     hub pull-request --no-edit --base Agoric/nat:master


### PR DESCRIPTION
## Description

This PR adds a CircleCI job that runs `npm audit` against both the top package.json and the integration-test package.json. 

If anything is automatically fixable (i.e. `npm audit --fix` is able to make changes), it submits a PR. 

If something comes up in the audit but is not automatically fixable, the CircleCI job fails and we should check it to see what we need to do. 