### PR TITLE
BREAKING CHANGE: Require Nat() to be a BigInt

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,13 @@ module.exports = {
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
   },
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module"
+  },
+  globals:{
+    BigInt: true
+  },
   rules: {
     'implicit-arrow-linebreak': 'off',
     'function-paren-newline': 'off',

--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,12 @@
  */
 
 function Nat(allegedNum) {
-  if (!Number.isSafeInteger(allegedNum)) {
-    throw new RangeError('not a safe integer');
+  if (typeof allegedNum !== "bigint") {
+    throw new TypeError(`${allegedNum} is not a BigInt`);
   }
 
   if (allegedNum < 0) {
-    throw new RangeError('negative');
+    throw new RangeError(`${allegedNum} is negative`);
   }
 
   return allegedNum;

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@
  */
 
 function Nat(allegedNum) {
-  if (typeof allegedNum !== "bigint") {
+  if (typeof allegedNum !== 'bigint') {
     throw new TypeError(`${allegedNum} is not a BigInt`);
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,23 +3,33 @@
 import test from 'tape';
 import Nat from '../src/index';
 
-test('Nat() throws when not a natural number', t => {
-  t.equal(Nat(0), 0);
-  t.equal(Nat(1), 1);
-  t.equal(Nat(999), 999);
-  t.equal(Nat(3.0), 3);
-  t.throws(() => Nat('not a number'), RangeError);
-  t.throws(() => Nat(-1), RangeError);
-  t.throws(() => Nat(0.5), RangeError);
-  t.throws(() => Nat(2 ** 60), RangeError);
-  t.throws(() => Nat(NaN), RangeError);
-  t.throws(() => Nat(Infinity), RangeError);
-  t.throws(() => Nat('3'), RangeError);
-  t.throws(() => Nat(3.1), RangeError);
+test('Nat() works for natural BigInts', t => {
+  t.equal(Nat(1n), 1n);
+  t.equal(Nat(BigInt('1')), BigInt('1'));
+  t.equal(Nat(BigInt('1')), 1n);
+  t.equals(Nat(BigInt(2 ** 53)), BigInt(2 ** 53));
+  t.equal(Nat(9007199254741000n), 9007199254741000n)
+  t.end();
+});
 
-  // works for safe integers only
-  t.equal(Nat(2 ** 53 - 1), 2 ** 53 - 1);
-  t.throws(() => Nat(2 ** 53), RangeError);
+test('Nat() throws for non-natural BigInts', t => {
+  t.throws(() => Nat(-1n), /RangeError: -1 is negative/);
+  t.end();
+});
 
+test('Nat() throws for non-BigInts', t => {
+  t.throws(() => Nat(0), /TypeError: 0 is not a BigInt/);
+  t.throws(() => Nat(1), /TypeError: 1 is not a BigInt/);
+  t.throws(() => Nat(999), /TypeError: 999 is not a BigInt/);
+  t.throws(() => Nat(3.0), /TypeError: 3 is not a BigInt/);
+  t.throws(() => Nat('not a number'), /TypeError: not a number is not a BigInt/);
+  t.throws(() => Nat(-1), /TypeError: -1 is not a BigInt/);
+  t.throws(() => Nat(0.5), /TypeError: 0.5 is not a BigInt/);
+  t.throws(() => Nat(2 ** 60), /TypeError: 1152921504606847000 is not a BigInt/);
+  t.throws(() => Nat(NaN), /TypeError: NaN is not a BigInt/);
+  t.throws(() => Nat(Infinity), /TypeError: Infinity is not a BigInt/);
+  t.throws(() => Nat('3'), /TypeError: 3 is not a BigInt/);
+  t.throws(() => Nat(3.1), /TypeError: 3.1 is not a BigInt/);
+  t.throws(() => Nat(2 ** 53 - 1), /TypeError: 9007199254740991 is not a BigInt/);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ test('Nat() works for natural BigInts', t => {
   t.equal(Nat(BigInt('1')), BigInt('1'));
   t.equal(Nat(BigInt('1')), 1n);
   t.equals(Nat(BigInt(2 ** 53)), BigInt(2 ** 53));
-  t.equal(Nat(9007199254741000n), 9007199254741000n)
+  t.equal(Nat(9007199254741000n), 9007199254741000n);
   t.end();
 });
 
@@ -22,14 +22,23 @@ test('Nat() throws for non-BigInts', t => {
   t.throws(() => Nat(1), /TypeError: 1 is not a BigInt/);
   t.throws(() => Nat(999), /TypeError: 999 is not a BigInt/);
   t.throws(() => Nat(3.0), /TypeError: 3 is not a BigInt/);
-  t.throws(() => Nat('not a number'), /TypeError: not a number is not a BigInt/);
+  t.throws(
+    () => Nat('not a number'),
+    /TypeError: not a number is not a BigInt/,
+  );
   t.throws(() => Nat(-1), /TypeError: -1 is not a BigInt/);
   t.throws(() => Nat(0.5), /TypeError: 0.5 is not a BigInt/);
-  t.throws(() => Nat(2 ** 60), /TypeError: 1152921504606847000 is not a BigInt/);
+  t.throws(
+    () => Nat(2 ** 60),
+    /TypeError: 1152921504606847000 is not a BigInt/,
+  );
   t.throws(() => Nat(NaN), /TypeError: NaN is not a BigInt/);
   t.throws(() => Nat(Infinity), /TypeError: Infinity is not a BigInt/);
   t.throws(() => Nat('3'), /TypeError: 3 is not a BigInt/);
   t.throws(() => Nat(3.1), /TypeError: 3.1 is not a BigInt/);
-  t.throws(() => Nat(2 ** 53 - 1), /TypeError: 9007199254740991 is not a BigInt/);
+  t.throws(
+    () => Nat(2 ** 53 - 1),
+    /TypeError: 9007199254740991 is not a BigInt/,
+  );
   t.end();
 });


### PR DESCRIPTION
This PR changes `Nat` to use `BigInts` instead of `numbers`. 

*To be followed immediately by a new release of Nat with the major version bumped (from 2.0.1 to 3.0.0)*

Note: This PR depends on #111. ESLint is failing because the older versions do not know about `'bigint'` as a type.