### PR TITLE
Add CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thank you!
+
+## Contact
+
+We use github issues for all bug reports: https://github.com/Agoric/nat/issues
+
+## Installing, Testing
+
+You'll need Node.js version 11 or higher. 
+
+* git clone https://github.com/Agoric/nat/
+* npm install
+* npm test
+
+## Pull Requests
+
+Before submitting a pull request, please:
+
+* run `npm test` and make sure all the unit tests pass
+* run `npm run lint-fix` to reformat the code according to our
+  `eslint` profile, and fix any complaints that it can't automatically
+  correct
+
+## Making a Release
+
+* edit NEWS.md enumerating any user-visible changes
+* `npm run build`
+* `npm version patch` (or `major` or `minor`)
+  * that changes `package.json` and `package-lock.json`
+  * and does a `git commit` and `git tag` by default
+  * to do `git commit` and `git tag` manually, use `--no-git-tag-version`
+  * to get signed tags, start with `npm config set sign-git-tag true`
+* `npm publish --access public`
+* `npm version prerelease --preid=dev`
+* `git push --tags`
+
+## Versioning
+
+While between releases, we use a version of "X.Y.Z-dev", where "X.Y.(Z-1)"
+was the previous release tag. This helps avoid confusion if/when people work
+from a git checkout, so bug reports to not make it look like they were using
+the previous tagged release.
+
+To achieve this, after doing a release, we run `npm version prerelease
+--preid=dev` to modify the `package.json` and `package-lock.json` with
+the new in-between version string.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Before submitting a pull request, please:
   * to get signed tags, start with `npm config set sign-git-tag true`
 * `npm publish --access public`
 * `npm version prerelease --preid=dev`
+* `git push`
 * `git push --tags`
 
 ## Versioning


### PR DESCRIPTION
I missed the `npm run build` step when I released Nat yesterday, so I think it would be a good idea to have a custom CONTRIBUTING.md for this repo in case we come back months later and need to release a new version. 